### PR TITLE
Add gallery screen UI with image grid and sharing

### DIFF
--- a/.kiro/specs/image-editor-app/tasks.md
+++ b/.kiro/specs/image-editor-app/tasks.md
@@ -62,7 +62,7 @@
   - Write unit tests for ViewModel logic and state transitions
   - _Requirements: 6.1, 6.3, 6.5, 7.3, 8.1_
 
-- [ ] 10. Create gallery screen UI with Compose
+- [x] 10. Create gallery screen UI with Compose
   - Implement GalleryScreen composable with LazyVerticalGrid for image display
   - Add image selection handling and navigation to editor
   - Implement long-press context menu for delete and share options

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/uaialternativa/imageeditor/MainActivity.kt
+++ b/app/src/main/java/com/uaialternativa/imageeditor/MainActivity.kt
@@ -5,12 +5,10 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.uaialternativa.imageeditor.ui.gallery.GalleryScreen
 import com.uaialternativa.imageeditor.ui.theme.ImageEditorTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -21,29 +19,31 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             ImageEditorTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                ImageEditorApp()
             }
         }
     }
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "1 1 Hello $name!",
-        modifier = modifier
+fun ImageEditorApp() {
+    GalleryScreen(
+        onImageSelected = { savedImage ->
+            // TODO: Navigate to image editor screen
+            // This will be implemented in a future task
+        },
+        onAddImageClicked = {
+            // TODO: Open image picker
+            // This will be implemented in a future task
+        },
+        modifier = Modifier.fillMaxSize()
     )
 }
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+fun ImageEditorAppPreview() {
     ImageEditorTheme {
-        Greeting("Android")
+        ImageEditorApp()
     }
 }

--- a/app/src/main/java/com/uaialternativa/imageeditor/ui/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/uaialternativa/imageeditor/ui/gallery/GalleryScreen.kt
@@ -1,0 +1,427 @@
+package com.uaialternativa.imageeditor.ui.gallery
+
+import android.content.Intent
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.uaialternativa.imageeditor.R
+import com.uaialternativa.imageeditor.domain.model.SavedImage
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Gallery screen displaying saved edited images in a grid layout
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GalleryScreen(
+    onImageSelected: (SavedImage) -> Unit,
+    onAddImageClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: GalleryViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    // Show error messages in snackbar
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let { error ->
+            snackbarHostState.showSnackbar(error)
+            viewModel.clearError()
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.gallery_title),
+                        style = MaterialTheme.typography.headlineMedium
+                    )
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = onAddImageClicked,
+                modifier = Modifier.semantics {
+                    contentDescription = context.getString(R.string.add_image_description)
+                }
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = stringResource(R.string.add_image_description)
+                )
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingValues ->
+        when {
+            uiState.isLoading -> {
+                LoadingState(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues)
+                )
+            }
+            uiState.images.isEmpty() -> {
+                EmptyState(
+                    onAddImageClicked = onAddImageClicked,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues)
+                )
+            }
+            else -> {
+                ImageGrid(
+                    images = uiState.images,
+                    onImageClick = onImageSelected,
+                    onImageDelete = { imageId ->
+                        viewModel.deleteImage(imageId)
+                    },
+                    onImageShare = { image ->
+                        shareImage(context, image)
+                    },
+                    isDeleting = uiState.isDeleting,
+                    deletingImageId = uiState.deletingImageId,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Loading state composable showing a centered progress indicator
+ */
+@Composable
+private fun LoadingState(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.semantics {
+                    contentDescription = "Loading images"
+                }
+            )
+            Text(
+                text = stringResource(R.string.loading_images),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+/**
+ * Empty state composable shown when no images are available
+ */
+@Composable
+private fun EmptyState(
+    onAddImageClicked: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Info,
+                contentDescription = null,
+                modifier = Modifier.size(120.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+            )
+            
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.empty_gallery_title),
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center
+                )
+                
+                Text(
+                    text = stringResource(R.string.empty_gallery_message),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(horizontal = 32.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Grid of images with support for click and long-press interactions
+ */
+@Composable
+private fun ImageGrid(
+    images: List<SavedImage>,
+    onImageClick: (SavedImage) -> Unit,
+    onImageDelete: (String) -> Unit,
+    onImageShare: (SavedImage) -> Unit,
+    isDeleting: Boolean,
+    deletingImageId: String?,
+    modifier: Modifier = Modifier
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(minSize = 150.dp),
+        modifier = modifier,
+        contentPadding = PaddingValues(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(
+            items = images,
+            key = { it.id }
+        ) { image ->
+            ImageGridItem(
+                image = image,
+                onClick = { onImageClick(image) },
+                onDelete = { onImageDelete(image.id) },
+                onShare = { onImageShare(image) },
+                isDeleting = isDeleting && deletingImageId == image.id
+            )
+        }
+    }
+}
+
+/**
+ * Individual image item in the grid with context menu support
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ImageGridItem(
+    image: SavedImage,
+    onClick: () -> Unit,
+    onDelete: () -> Unit,
+    onShare: () -> Unit,
+    isDeleting: Boolean,
+    modifier: Modifier = Modifier
+) {
+    var showContextMenu by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    
+    val dateFormatter = remember {
+        SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+    }
+
+    Card(
+        modifier = modifier
+            .aspectRatio(1f)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = { showContextMenu = true }
+            )
+            .semantics {
+                contentDescription = "Image ${image.fileName}, created ${dateFormatter.format(Date(image.createdAt))}"
+            },
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Box {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(File(image.filePath))
+                    .crossfade(true)
+                    .build(),
+                contentDescription = "Edited image: ${image.originalFileName ?: image.fileName}",
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(12.dp)),
+                contentScale = ContentScale.Crop
+            )
+            
+            // Show loading overlay when deleting
+            if (isDeleting) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            Color.Black.copy(alpha = 0.5f),
+                            RoundedCornerShape(12.dp)
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Deleting image"
+                        }
+                    )
+                }
+            }
+            
+            // Image info overlay
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        Color.Black.copy(alpha = 0.6f),
+                        RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp)
+                    )
+                    .padding(8.dp)
+                    .align(Alignment.BottomCenter)
+            ) {
+                Column {
+                    Text(
+                        text = image.originalFileName ?: image.fileName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.White,
+                        maxLines = 1
+                    )
+                    Text(
+                        text = "${image.width} × ${image.height}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color.White.copy(alpha = 0.8f)
+                    )
+                }
+            }
+            
+            // Context menu
+            DropdownMenu(
+                expanded = showContextMenu,
+                onDismissRequest = { showContextMenu = false }
+            ) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.share)) },
+                    onClick = {
+                        showContextMenu = false
+                        onShare()
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.Share,
+                            contentDescription = null
+                        )
+                    }
+                )
+                
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.delete)) },
+                    onClick = {
+                        showContextMenu = false
+                        onDelete()
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = null
+                        )
+                    }
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Share an image using the system share intent
+ */
+private fun shareImage(context: android.content.Context, image: SavedImage) {
+    try {
+        val imageFile = File(image.filePath)
+        if (imageFile.exists()) {
+            val imageUri = FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.fileprovider",
+                imageFile
+            )
+            
+            val shareIntent = Intent().apply {
+                action = Intent.ACTION_SEND
+                type = "image/*"
+                putExtra(Intent.EXTRA_STREAM, imageUri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            
+            context.startActivity(
+                Intent.createChooser(shareIntent, context.getString(R.string.share_image))
+            )
+        }
+    } catch (e: Exception) {
+        // Handle sharing error - could show a toast or snackbar
+        e.printStackTrace()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,13 @@
 <resources>
     <string name="app_name">ImageEditor</string>
+    
+    <!-- Gallery Screen -->
+    <string name="gallery_title">Gallery</string>
+    <string name="add_image_description">Add new image to edit</string>
+    <string name="loading_images">Loading images…</string>
+    <string name="empty_gallery_title">No images yet</string>
+    <string name="empty_gallery_message">Start editing your first image by tapping the + button</string>
+    <string name="share">Share</string>
+    <string name="delete">Delete</string>
+    <string name="share_image">Share image</string>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path name="edited_images" path="edited_images/" />
+</paths>


### PR DESCRIPTION
Implements the GalleryScreen composable using Jetpack Compose, displaying saved images in a grid with support for selection, sharing, and deletion. Adds required string resources, updates the manifest to include FileProvider for sharing images, and adds file_paths.xml for secure file access. MainActivity now launches the gallery screen as the app's main UI.